### PR TITLE
RST-1884: Maintenance Notice when Env Var is Present

### DIFF
--- a/app/assets/stylesheets/global.css
+++ b/app/assets/stylesheets/global.css
@@ -12,3 +12,9 @@
     font-size: 0.85em;
     float: right;
 }
+
+.maintenance-notice p {
+    border: 5px solid #005ea5;
+    margin-top: 0.5em;
+    padding: 0.25em 0.5em;
+}

--- a/app/assets/stylesheets/global.css
+++ b/app/assets/stylesheets/global.css
@@ -14,7 +14,8 @@
 }
 
 .maintenance-notice p {
-    border: 5px solid #005ea5;
+    border: 3px solid #005ea5;
     margin-top: 0.5em;
     padding: 0.25em 0.5em;
+    font-size: 0.85em;
 }

--- a/app/helpers/maintenance_notice_helper.rb
+++ b/app/helpers/maintenance_notice_helper.rb
@@ -1,0 +1,11 @@
+module MaintenanceNoticeHelper
+  def maintenance_notice
+    (start_time, end_time) = ENV['SHOW_DOWNTIME_BANNER'].split(',').
+        map { |d|  Time.zone.parse(d.strip).strftime("%l%P") }
+
+    day = Time.zone.parse(ENV['SHOW_DOWNTIME_BANNER'].split(',').last.strip).strftime("%e %B %Y")
+
+    "We're planning maintenance of this service. It will be unavailable from #{start_time} to #{end_time} on #{day}."
+  end
+
+end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -25,8 +25,12 @@
           .column-full
             .switch-language
               = link_to t('components.common.language'), locale: t('components.common.locale')
-        .column-full.maintenance-notice
-          p We're planning maintenance of this service. It will be unavailable from 9am to 2pm on 15 May 2019.
+        - if ENV['SHOW_DOWNTIME_BANNER'].present?
+          .column-full.maintenance-notice
+            - start_time = DateTime.parse(ENV['SHOW_DOWNTIME_BANNER'].split(',').first).strftime("%l%P").strip
+            - end_time = DateTime.parse(ENV['SHOW_DOWNTIME_BANNER'].split(',').last).strftime("%l%P").strip
+            - day = DateTime.parse(ENV['SHOW_DOWNTIME_BANNER'].split(',').last).strftime("%e %B %Y")
+            p = "We're planning maintenance of this service. It will be unavailable from #{start_time} to #{end_time} on #{day}."
         .column-two-thirds
           .content-header
             h2.heading-medium data-behavior="heading" = yield(:form_page_title)

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -25,12 +25,7 @@
           .column-full
             .switch-language
               = link_to t('components.common.language'), locale: t('components.common.locale')
-        - if ENV['SHOW_DOWNTIME_BANNER'].present?
-          .column-full.maintenance-notice
-            - start_time = DateTime.parse(ENV['SHOW_DOWNTIME_BANNER'].split(',').first).strftime("%l%P").strip
-            - end_time = DateTime.parse(ENV['SHOW_DOWNTIME_BANNER'].split(',').last).strftime("%l%P").strip
-            - day = DateTime.parse(ENV['SHOW_DOWNTIME_BANNER'].split(',').last).strftime("%e %B %Y")
-            p = "We're planning maintenance of this service. It will be unavailable from #{start_time} to #{end_time} on #{day}."
+        = render "shared/maintenance_notice" if ENV['SHOW_DOWNTIME_BANNER'].present?
         .column-two-thirds
           .content-header
             h2.heading-medium data-behavior="heading" = yield(:form_page_title)

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -25,6 +25,8 @@
           .column-full
             .switch-language
               = link_to t('components.common.language'), locale: t('components.common.locale')
+        .column-full.maintenance-notice
+          p We're planning maintenance of this service. It will be unavailable from 9am to 2pm on 15 May 2019.
         .column-two-thirds
           .content-header
             h2.heading-medium data-behavior="heading" = yield(:form_page_title)

--- a/app/views/shared/_maintenance_notice.html.slim
+++ b/app/views/shared/_maintenance_notice.html.slim
@@ -1,0 +1,2 @@
+.column-full.maintenance-notice
+  p = maintenance_notice


### PR DESCRIPTION
### Change description ###

When `SHOW_DOWNTIME_BANNER` environment variable is present, this PR ensures that a maintenance banner is shown on all service pages.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
