### PR TITLE
SSL Certificate Verification Control 

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,6 +92,7 @@ Rails.application.configure do
 
   Raven.configure do |config|
     config.dsn = ENV.fetch('RAVEN_DSN', '')
+    config.ssl_verification = ENV.fetch('RAVEN_SSL_VERIFICATION', 'true').downcase == 'true'
   end
 
   # The google tag manager account - fetched from environment variable, defaulting to false.  An empty string in the env


### PR DESCRIPTION
This PR allows configuration of the raven client to allow SSL certificate verification to be disabled by setting RAVEN_SSL_VERIFICATION=false as an environment variable (defaults to true)