### PR TITLE
RST-1922: Prevent 500 error when switching from cy to en when session expires

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,13 +16,13 @@ Rails.application.routes.draw do
     get "/terms" => 'static_pages#terms', as: 'terms_and_conditions'
     get "/privacy" => 'static_pages#privacy', as: 'privacy_notice'
     get "/cookies" => 'static_pages#cookies'
+    get "/session_expired" => 'static_pages#expired'
     root 'static_pages#index'
     delete "/respond/confirmation_of_supplied_details/remove_rtf" => 'confirmation_of_supplied_details#destroy_rtf', as: :remove_rtf
     mount EtDropzoneUploader::Engine, at: '/api/v2/build_blob'
     # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   end
   put "/" => 'static_pages#start_new_session', as: 'start_new_session'
-  get "/session_expired" => 'static_pages#expired'
   get "/ping" => "status#ping"
   get "/healthcheck" => "status#healthcheck"
 end


### PR DESCRIPTION
### Change description ###

Previously 500 error was shown when switching from Welsh to English on 'session expired' page. Add locale to path to enable the user to switch between languages.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
