### PR TITLE
RST-1950: Update .travis.yml to work with webdrivers gem in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ before_script:
   - ./bin/wait-for-it.sh localhost:5433
   - ./bin/wait-for-it.sh localhost:10000
   - bundle exec rake parallel:create parallel:migrate
+  - bundle exec rake webdrivers:chromedriver:update
+  - bundle exec rake webdrivers:geckodriver:update
 script:
   - bundle exec rake parallel:spec
   - TEST_LOCALE=cy bundle exec rake parallel:spec


### PR DESCRIPTION
### Change description ###

When we switched from chromedriver-helper to webdrivers, travis seemed to be getting flaky. This was due to webdrivers having issues with downloading the drivers while in parallel. In v4 of the gem they added rake tasks to update the drivers before running the parallel specs, this PR adds them, which should fix the flaky travis builds.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
