### PR TITLE
Took of the link for a blank pdf on all services pages.

### DIFF
--- a/app/views/static_pages/index.html.slim
+++ b/app/views/static_pages/index.html.slim
@@ -33,7 +33,6 @@
     .sidebar-content
       p = link_to(t('components.sidebar.claim_link'), t('components.sidebar.claim_href'), target: :_blank)
       p = link_to(t('components.sidebar.response_link'), t('components.sidebar.response_href'), target: :_blank)
-      p = link_to(t('components.sidebar.download_link'), t('components.sidebar.download_href'), target: :_blank)
       hr
       p = link_to(t('components.sidebar.more_category_link'), t('components.sidebar.more_category_href'), target: :_blank)
 

--- a/spec/features/view_sidebar_spec.rb
+++ b/spec/features/view_sidebar_spec.rb
@@ -8,7 +8,6 @@ RSpec.feature "View Sidebar", js: true do
 
     expect(start_page.sidebar).to have_link(t('components.sidebar.claim_link'), href: t('components.sidebar.claim_href'))
     expect(start_page.sidebar).to have_link(t('components.sidebar.response_link'), href: t('components.sidebar.response_href'))
-    expect(start_page.sidebar).to have_link(t('components.sidebar.download_link'), href: t('components.sidebar.download_href'))
     expect(start_page.sidebar).to have_link(t('components.sidebar.more_category_link'), href: t('components.sidebar.more_category_href'))
   end
 


### PR DESCRIPTION
The link inside the sidebar menu for a blank pdf has been taken off all services pages.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
