### PR TITLE
RST-3739 Users are now sign out on start page - Closed tab

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,7 +1,7 @@
 class StaticPagesController < ApplicationController
   skip_before_action :authenticate_user!
   skip_before_action :set_start_session_timer
-  before_action :sign_out_user
+  before_action :sign_out_user, only: :index
 
   def index; end
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -16,6 +16,8 @@ class StaticPagesController < ApplicationController
     redirect_to edit_respondents_details_path
   end
 
+  private
+
   def sign_out_user
     sign_out
   end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,6 +1,7 @@
 class StaticPagesController < ApplicationController
   skip_before_action :authenticate_user!
   skip_before_action :set_start_session_timer
+  before_action :sign_out_user
 
   def index; end
 
@@ -13,5 +14,9 @@ class StaticPagesController < ApplicationController
   def start_new_session
     clear_session_data
     redirect_to edit_respondents_details_path
+  end
+
+  def sign_out_user
+    sign_out
   end
 end

--- a/app/views/static_pages/index.html.slim
+++ b/app/views/static_pages/index.html.slim
@@ -25,8 +25,8 @@
     h4.heading-small = t('components.introduction.data_title')
     p = t('components.introduction.data_content')
 
-    = link_to t('components.introduction.start_now'), new_user_registration_path, class: 'button button-start'
-    = link_to t('components.introduction.return_to_claim'), new_user_session_path, class: 'button-return'
+  = link_to t('components.introduction.start_now'), new_user_registration_path, class: 'button button-start'
+  = link_to t('components.introduction.return_to_claim'), new_user_session_path, class: 'button-return'
 
   - content_for :sidebar
     .sidebar

--- a/app/views/static_pages/index.html.slim
+++ b/app/views/static_pages/index.html.slim
@@ -25,8 +25,8 @@
     h4.heading-small = t('components.introduction.data_title')
     p = t('components.introduction.data_content')
 
-  = link_to t('components.introduction.start_now'), new_user_registration_path, class: 'button button-start'
-  = link_to t('components.introduction.return_to_claim'), new_user_session_path, class: 'button-return'
+    = link_to t('components.introduction.start_now'), new_user_registration_path, class: 'button button-start'
+    = link_to t('components.introduction.return_to_claim'), new_user_session_path, class: 'button-return'
 
   - content_for :sidebar
     .sidebar

--- a/spec/features/access_start_page_spec.rb
+++ b/spec/features/access_start_page_spec.rb
@@ -37,4 +37,18 @@ RSpec.feature "Access Start Page", js: true do
 
     expect(respondents_details_page).to be_displayed
   end
+
+  scenario "user will be able to close tab and start a new claim" do
+    given_valid_user
+    start_page.load(locale: current_locale_parameter)
+    start_page.next
+    registration_start
+
+    expect(respondents_details_page).to be_displayed
+
+    start_page.load(locale: current_locale_parameter)
+    start_page.next
+
+    expect(registration_page).to be_displayed
+  end
 end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,4 +1,4 @@
 require 'webmock/rspec'
 app_host = ENV.fetch('CAPYBARA_SERVER_HOST', ENV.fetch('HOSTNAME', `hostname`.strip))
 storage_host = URI.parse(ENV.fetch('AZURE_STORAGE_BLOB_HOST', 'http://azure_blob_storage.et.127.0.0.1.nip.io:1000')).host
-WebMock.disable_net_connect!(allow: [app_host, 'chromedriver.storage.googleapis.com', storage_host, 'github.com'], allow_localhost: true)
+WebMock.disable_net_connect!(allow: [app_host, 'chromedriver.storage.googleapis.com', storage_host, 'github.com', 'objects.githubusercontent.com'], allow_localhost: true)


### PR DESCRIPTION
Added a before action on the static pages. So when a user close a tab or go back to the start page it will be automatically signed out.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
