### PR TITLE
RST-2614 Validation for et3 responses - allowing 6 or 8 as the first digit for reform ET1 cases

### DIFF
--- a/app/validators/case_number_validator.rb
+++ b/app/validators/case_number_validator.rb
@@ -1,5 +1,5 @@
 class CaseNumberValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    record.errors.add(attribute, :invalid) unless value =~ %r{\A(13|14|16|18|22|23|24|25|26|32|33|41|99)\d{5}\/\d{4}\z}
+    record.errors.add(attribute, :invalid) unless value =~ %r{\A(13|14|16|18|22|23|24|25|26|32|33|41|99|6\d|8\d)\d{5}\/\d{4}\z}
   end
 end

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -6,34 +6,6 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
     - "${DB_PORT:-5432}:5432"
-  zalenium:
-    image: "dosel/zalenium"
-    hostname: zalenium
-    tty: true
-    volumes:
-      - /tmp/videos:/home/seluser/videos
-      - /var/run/docker.sock:/var/run/docker.sock
-    ports:
-      - ${SELENIUM_PORT:-4444}:4444
-    command: >
-      start --desiredContainers 2
-            --maxDockerSeleniumContainers 8
-            --screenWidth 1280 --screenHeight 720
-            --timeZone "Europe/Berlin"
-            --videoRecordingEnabled true
-            --sauceLabsEnabled false
-            --browserStackEnabled false
-            --testingBotEnabled false
-            --startTunnel false
-    environment:
-      - HOST_UID
-      - HOST_GID
-      - SAUCE_USERNAME
-      - SAUCE_ACCESS_KEY
-      - BROWSER_STACK_USER
-      - BROWSER_STACK_KEY
-      - TESTINGBOT_KEY
-      - TESTINGBOT_SECRET
   azurite:
     image: mcr.microsoft.com/azurestorage-azurite:2.6.7
     ports:
@@ -42,6 +14,5 @@ services:
       - azurite_data:/opt/azurite/folder
     environment:
       executable: blob
-
 volumes:
   azurite_data:

--- a/spec/validators/case_number_validator_spec.rb
+++ b/spec/validators/case_number_validator_spec.rb
@@ -61,4 +61,20 @@ RSpec.describe CaseNumberValidator do
     expect(model.errors.details[:case_number]).to include a_hash_including(error: :invalid)
   end
 
+  it 'will validate a string of the correct format starting with "6" for the "new reformed ET1" cases' do
+    model = model_class.new(case_number: "6054321/2017")
+
+    model.valid?
+
+    expect(model.errors).not_to include :case_number
+  end
+
+  it 'will validate a string of the correct format starting with "8" for the "new reformed ET1" cases' do
+    model = model_class.new(case_number: "8054321/2017")
+
+    model.valid?
+
+    expect(model.errors).not_to include :case_number
+  end
+
 end


### PR DESCRIPTION


**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-4614

### Change description ###

Allows '6' or '8' as the first digit of a case reference to allow for new ET1 cases from the reform system

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
